### PR TITLE
refactor: Improve subvolume handling, add unit tests, and enhance luminosity unit specification

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [main, master]
   pull_request:
-    branches: [ main, master ]
+    branches: [main, master]
 
 jobs:
   test:
@@ -14,27 +14,28 @@ jobs:
         python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pytest pytest-cov
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        if [ -f docs/requirements.txt ]; then pip install -r docs/requirements.txt; fi
-    
-    - name: Run tests with pytest
-      run: |
-        pytest tests/ -v --cov=src --cov-report=xml
-    
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
-      with:
-        file: ./coverage.xml
-        flags: unittests
-        fail_ci_if_error: false
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-cov
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f docs/requirements.txt ]; then pip install -r docs/requirements.txt; fi
+
+      - name: Run tests with pytest
+        run: |
+          export PYTHONPATH="${PYTHONPATH}:${GITHUB_WORKSPACE}/src"
+          pytest tests/ --cov=src/gne --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ parts/
 sdist/
 var/
 venv/
+.venv/
 *.egg-info/
 .installed.cfg
 *.egg

--- a/data/slurm_templates/slurm_taurus_template.sh
+++ b/data/slurm_templates/slurm_taurus_template.sh
@@ -9,6 +9,7 @@
 #SBATCH --output=__GNE_LOG_DIR__/__GNE_JOB_NAME__.out
 ##SBATCH --mem=600000
 #SBATCH --partition=all
+#SBATCH --exclude=epi
 #SBATCH --time=30-00:00:00
 #
 export OMP_NUM_THREADS=16

--- a/run_hdf5input_tutorial.py
+++ b/run_hdf5input_tutorial.py
@@ -54,9 +54,11 @@ units_h0=True
 # units_Gyr=False if input units [SFR,Mdot]=[Mass]/yr (default)
 # units_Gyr=True  if input units [SFR,Mdot]=[Mass]/Gyr 
 units_Gyr=True 
-# units_L40h2=False if input units [L]=erg/s  (default)
-# units_L40h2=True  if input units [L]=1e40 h^-2 erg/s
-units_L40h2=True
+# Type of input units for luminosity, per component:
+# 0: input units [L]=erg/s  (default);
+# 1: input units [L]=1e40 h^-2 erg/s
+# 2: input units [L]=1e40 erg/s
+units_L40h2=1
 
 ####################################################
 ############  Emission from SF regions #############

--- a/run_hdf5input_tutorial.py
+++ b/run_hdf5input_tutorial.py
@@ -58,7 +58,7 @@ units_Gyr=True
 # 0: input units [L]=erg/s  (default);
 # 1: input units [L]=1e40 h^-2 erg/s
 # 2: input units [L]=1e40 erg/s
-units_L40h2=1
+units_L=1
 
 ####################################################
 ############  Emission from SF regions #############
@@ -289,7 +289,7 @@ for ivol in range(subvols):
         # Obtain nebular emission lines
         gne(infile,redshift,snapshot,h0,omega0,omegab,lambda0,vol,mp,
             inputformat=inputformat,outpath=outpath,
-            units_h0=units_h0,units_Gyr=units_Gyr,units_L40h2=units_L40h2,
+            units_h0=units_h0,units_Gyr=units_Gyr,units_L=units_L,
             model_nH_sfr=model_nH_sfr, model_U_sfr=model_U_sfr,
             photmod_sfr=photmod_sfr,
             m_sfr_z=m_sfr_z,mtot2mdisk=mtot2mdisk,

--- a/run_txtinput_tutorial.py
+++ b/run_txtinput_tutorial.py
@@ -57,9 +57,11 @@ units_h0=True
 # units_Gyr=False if input units [SFR,Mdot]=[Mass]/yr (default)
 # units_Gyr=True  if input units [SFR,Mdot]=[Mass]/Gyr 
 units_Gyr=True 
-# units_L40h2=False if input units [L]=erg/s  (default)
-# units_L40h2=True  if input units [L]=1e40 h^-2 erg/s
-units_L40h2=True
+# Type of input units for luminosity, per component:
+# 0: input units [L]=erg/s  (default);
+# 1: input units [L]=1e40 h^-2 erg/s
+# 2: input units [L]=1e40 erg/s
+units_L40h2=1
 
 ####################################################
 ############  Emission from SF regions #############

--- a/run_txtinput_tutorial.py
+++ b/run_txtinput_tutorial.py
@@ -61,7 +61,7 @@ units_Gyr=True
 # 0: input units [L]=erg/s  (default);
 # 1: input units [L]=1e40 h^-2 erg/s
 # 2: input units [L]=1e40 erg/s
-units_L40h2=1
+units_L=1
 
 ####################################################
 ############  Emission from SF regions #############
@@ -265,7 +265,7 @@ for ivol in range(subvols):
     if get_emission_lines:  # Obtain nebular emission lines
         gne(infile,redshift,snapshot,h0,omega0,omegab,lambda0,vol,mp,
             inputformat=inputformat,outpath=outpath,
-            units_h0=units_h0,units_Gyr=units_Gyr,units_L40h2=units_L40h2,
+            units_h0=units_h0,units_Gyr=units_Gyr,units_L=units_L,
             model_nH_sfr=model_nH_sfr, model_U_sfr=model_U_sfr,
             photmod_sfr=photmod_sfr,
             m_sfr_z=m_sfr_z,mtot2mdisk=mtot2mdisk,

--- a/src/gne/gne.py
+++ b/src/gne/gne.py
@@ -17,7 +17,7 @@ from gne.gne_plots import make_testplots
 
 def gne(infile,redshift,snap,h0,omega0,omegab,lambda0,vol,mp,
         inputformat='hdf5',outpath=None,out_ending=None,
-        units_h0=False,units_Gyr=False,units_L40h2=False,
+        units_h0=False,units_Gyr=False,units_L40h2=0,
         model_nH_sfr='kashino19',model_U_sfr='kashino19',
         photmod_sfr='gutkin16',nH_sfr=c.nH_sfr_cm3,
         q0=c.q0_orsi, z0=c.Z0_orsi, gamma=c.gamma_orsi,
@@ -136,8 +136,10 @@ def gne(infile,redshift,snap,h0,omega0,omegab,lambda0,vol,mp,
         True if input units with h
     units_Gyr: boolean
         True if input units with */Gyr
-    units_L40h2: boolean
-        True if input units with 1e40erg/s
+    units_L40h2: integer
+        0: input units [L]=erg/s  (default);
+        1: input units [L]=1e40 h^-2 erg/s
+        2: input units [L]=1e40 erg/s
     testing : boolean
         If True only run over few entries for testing purposes
     verbose : boolean

--- a/src/gne/gne.py
+++ b/src/gne/gne.py
@@ -17,7 +17,7 @@ from gne.gne_plots import make_testplots
 
 def gne(infile,redshift,snap,h0,omega0,omegab,lambda0,vol,mp,
         inputformat='hdf5',outpath=None,out_ending=None,
-        units_h0=False,units_Gyr=False,units_L40h2=0,
+        units_h0=False,units_Gyr=False,units_L=0,
         model_nH_sfr='kashino19',model_U_sfr='kashino19',
         photmod_sfr='gutkin16',nH_sfr=c.nH_sfr_cm3,
         q0=c.q0_orsi, z0=c.Z0_orsi, gamma=c.gamma_orsi,
@@ -136,7 +136,7 @@ def gne(infile,redshift,snap,h0,omega0,omegab,lambda0,vol,mp,
         True if input units with h
     units_Gyr: boolean
         True if input units with */Gyr
-    units_L40h2: integer
+    units_L: integer
         0: input units [L]=erg/s  (default);
         1: input units [L]=1e40 h^-2 erg/s
         2: input units [L]=1e40 erg/s
@@ -296,7 +296,7 @@ def gne(infile,redshift,snap,h0,omega0,omegab,lambda0,vol,mp,
         Lagn = get_Lagn(infile,cut,inputformat=inputformat,
                         params=Lagn_params,Lagn_inputs=Lagn_inputs,
                         h0=h0,units_h0=units_h0,
-                        units_Gyr=units_Gyr,units_L40h2=units_L40h2,
+                        units_Gyr=units_Gyr,units_L=units_L,
                         testing=testing,verbose=verbose)
 
         # Get the ionising parameter, U, (and filling factor)

--- a/src/gne/gne_Lagn.py
+++ b/src/gne/gne_Lagn.py
@@ -207,7 +207,7 @@ def Rsch(Mbh):
 
 
 def get_Lagn(infile,cut,inputformat='hdf5',params='Lagn',Lagn_inputs='Lagn',
-             h0=None,units_h0=False,units_Gyr=False,units_L40h2=0,
+             h0=None,units_h0=False,units_Gyr=False,units_L=0,
              kagn=c.kagn,kagn_exp=c.kagn_exp,testing=False,verbose=True):
     '''
     Calculate or get the bolometric luminosity of BHs (erg/s) 
@@ -228,7 +228,7 @@ def get_Lagn(infile,cut,inputformat='hdf5',params='Lagn',Lagn_inputs='Lagn',
         True if input units with h
     units_Gyr: boolean
         True if input units with */Gyr
-    units_L40h2: integer
+    units_L: integer
         0: input units [L]=erg/s  (default);
         1: input units [L]=1e40 h^-2 erg/s
         2: input units [L]=1e40 erg/s
@@ -253,14 +253,14 @@ def get_Lagn(infile,cut,inputformat='hdf5',params='Lagn',Lagn_inputs='Lagn',
     
     if Lagn_inputs=='Lagn':
         Lagn = vals[0]
-        if units_L40h2==1:
+        if units_L==1:
             cfac = 1e40/(h0*h0)
             Lagn = Lagn*cfac
-        elif units_L40h2==2:
+        elif units_L==2:
             cfac = 1e40
             Lagn = Lagn*cfac
-        elif units_L40h2!=0:
-            raise ValueError('units_L40h2 must be 0, 1 or 2')
+        elif units_L!=0:
+            raise ValueError('units_L must be 0, 1 or 2')
         return Lagn # erg/s
     
     elif Lagn_inputs=='Mdot_hh':

--- a/src/gne/gne_Lagn.py
+++ b/src/gne/gne_Lagn.py
@@ -207,7 +207,7 @@ def Rsch(Mbh):
 
 
 def get_Lagn(infile,cut,inputformat='hdf5',params='Lagn',Lagn_inputs='Lagn',
-             h0=None,units_h0=False,units_Gyr=False,units_L40h2=False,
+             h0=None,units_h0=False,units_Gyr=False,units_L40h2=0,
              kagn=c.kagn,kagn_exp=c.kagn_exp,testing=False,verbose=True):
     '''
     Calculate or get the bolometric luminosity of BHs (erg/s) 
@@ -228,8 +228,10 @@ def get_Lagn(infile,cut,inputformat='hdf5',params='Lagn',Lagn_inputs='Lagn',
         True if input units with h
     units_Gyr: boolean
         True if input units with */Gyr
-    units_L40h2: boolean
-        True if input units with 1e40erg/s
+    units_L40h2: integer
+        0: input units [L]=erg/s  (default);
+        1: input units [L]=1e40 h^-2 erg/s
+        2: input units [L]=1e40 erg/s
     kagn : float
         Multiplicative factor for units Msun/yr, radio mode
     kagn_exp : float
@@ -251,9 +253,14 @@ def get_Lagn(infile,cut,inputformat='hdf5',params='Lagn',Lagn_inputs='Lagn',
     
     if Lagn_inputs=='Lagn':
         Lagn = vals[0]
-        if units_L40h2:
+        if units_L40h2==1:
             cfac = 1e40/(h0*h0)
             Lagn = Lagn*cfac
+        elif units_L40h2==2:
+            cfac = 1e40
+            Lagn = Lagn*cfac
+        elif units_L40h2!=0:
+            raise ValueError('units_L40h2 must be 0, 1 or 2')
         return Lagn # erg/s
     
     elif Lagn_inputs=='Mdot_hh':

--- a/src/gne/gne_plots.py
+++ b/src/gne/gne_plots.py
@@ -857,7 +857,7 @@ def plot_uzn(root, endf, subvols=1, outpath=None, verbose=True):
        Path to files with calculated data (lines, etc)
     endf : string
        Ending of input files. 
-    subvols: integer
+    subvols: integer or list of integers
         Number of subvolumes to be considered
     outpath : string
         Path to output, default is output/ 
@@ -944,7 +944,11 @@ def plot_uzn(root, endf, subvols=1, outpath=None, verbose=True):
         tota, ina, inna = [np.zeros(1) for i in range(3)]
 
     # Read data in each subvolume
-    for ivol in range(subvols):
+    list_subvols = subvols
+    if isinstance(subvols, int):
+        list_subvols = list(range(subvols))
+
+    for ivol in list_subvols:
         filenom = os.path.join(root+'0',endf) #; print(filenom); exit()
         f = h5py.File(filenom, 'r'); header = f['header']
 
@@ -1315,7 +1319,7 @@ def plot_bpts(root, endf, subvols=1, outpath=None, verbose=True):
        Path to input files. 
     endf : string
        Ending of input files. 
-    subvols: integer
+    subvols: integer or list of integers
         Number of subvolumes to be considered
     outpath : string
         Path to output, default is output/ 
@@ -1381,7 +1385,11 @@ def plot_bpts(root, endf, subvols=1, outpath=None, verbose=True):
 
     # Read data in each subvolume and add data to plots
     seltot = 0
-    for ivol in range(subvols): ###here to go over subvols, not a range
+    list_subvols = subvols
+    if isinstance(subvols, int):
+        list_subvols = list(range(subvols))
+    
+    for ivol in list_subvols: ###here to go over subvols, not a range
         filenom = os.path.join(root+str(ivol),endf)
         f = h5py.File(filenom, 'r')
         
@@ -1581,7 +1589,7 @@ def plot_lfs(root, endf, subvols=1, outpath=None, verbose=True):
        Path to input files. 
     endf : string
        Ending of input files. 
-    subvols: integer
+    subvols: integer or list of integers
         Number of subvolumes to be considered
     outpath : string
         Path to output, default is output/ 
@@ -1646,7 +1654,11 @@ def plot_lfs(root, endf, subvols=1, outpath=None, verbose=True):
     lf_att = np.zeros((nlines, len(lhist)))
 
     # Read data from each subvolume
-    for ivol in range(subvols):
+    list_subvols = subvols
+    if isinstance(subvols, int):
+        list_subvols = list(range(subvols))
+    
+    for ivol in list_subvols:
         filenom = os.path.join(root+str(ivol),endf)
         f = h5py.File(filenom, 'r')
 
@@ -1808,7 +1820,7 @@ def plot_ncumu_flux(root, endf, subvols=1, outpath=None, verbose=True):
        Path to input files. 
     endf : string
        Ending of input files. 
-    subvols: integer
+    subvols: integer or list of integers
         Number of subvolumes to be considered
     outpath : string
         Path to output, default is output/ 
@@ -1876,7 +1888,11 @@ def plot_ncumu_flux(root, endf, subvols=1, outpath=None, verbose=True):
     ncum_att = np.zeros((nlines, len(fbins)))
 
     # Read data from each subvolume
-    for ivol in range(subvols):
+    list_subvols = subvols
+    if isinstance(subvols, int):
+        list_subvols = list(range(subvols))
+    
+    for ivol in list_subvols:
         filenom = os.path.join(root+str(ivol),endf)
         f = h5py.File(filenom, 'r')
 
@@ -2048,7 +2064,7 @@ def make_testplots(snap,ending,outpath=None,
        End name of input files
     outpath : string
        Path to input files
-    subvols: integer
+    subvols: integer or list of integers
         Number of subvolumes to be considered
     outpath : string
         Path to output, default is output/ 

--- a/src/gne/gne_plots.py
+++ b/src/gne/gne_plots.py
@@ -948,6 +948,8 @@ def plot_uzn(root, endf, subvols=1, outpath=None, verbose=True):
     if isinstance(subvols, int):
         list_subvols = list(range(subvols))
 
+    first_vol = True
+
     for ivol in list_subvols:
         filenom = os.path.join(root+'0',endf) #; print(filenom); exit()
         f = h5py.File(filenom, 'r'); header = f['header']
@@ -969,7 +971,7 @@ def plot_uzn(root, endf, subvols=1, outpath=None, verbose=True):
                 epsilon1 = f['agn_data/epsilon_NLR'][:]
         f.close()
 
-        if ivol == 0:
+        if first_vol:
             lusfr = lusfr1; lzsfr = lzsfr1
             lnsfr = lnsfr1; lms = lms1
             if AGN:
@@ -977,6 +979,7 @@ def plot_uzn(root, endf, subvols=1, outpath=None, verbose=True):
                 Lagn = Lagn1
                 if not epsilon_is_constant:
                     epsilon = epsilon1    
+            first_vol = False
         else:
             lusfr = np.append(lusfr,lusfr1,axis=0)
             lzsfr = np.append(lzsfr,lzsfr1,axis=0)
@@ -1388,6 +1391,8 @@ def plot_bpts(root, endf, subvols=1, outpath=None, verbose=True):
     list_subvols = subvols
     if isinstance(subvols, int):
         list_subvols = list(range(subvols))
+
+    chatot = None
     
     for ivol in list_subvols: ###here to go over subvols, not a range
         filenom = os.path.join(root+str(ivol),endf)
@@ -1525,7 +1530,7 @@ def plot_bpts(root, endf, subvols=1, outpath=None, verbose=True):
         axs.scatter(xx,yy, c=cha,s=50, marker='o', cmap=cmap)
 
         # Join all data for the colourbar
-        if ivol == 0:
+        if chatot is None:
             chatot = cha
         else:
             chatot = np.append(chatot,cha)
@@ -1795,7 +1800,7 @@ def plot_lfs(root, endf, subvols=1, outpath=None, verbose=True):
         ax.set_ylim([ymin, ymax])
         ax.minorticks_on()
         ax.set_xlabel(xtit); ax.set_ylabel(ytit)
-        if (iline==0):
+        if (iline==0) and len(ind[0]) > 0:
             ax.legend(loc='best',frameon=False)
     
     plt.tight_layout()
@@ -2016,7 +2021,8 @@ def plot_ncumu_flux(root, endf, subvols=1, outpath=None, verbose=True):
                     ax.plot(x, y,'--',color=color,label=ll)
             
         # Legend
-        ax.legend(loc='best',frameon=False)
+        if len(ind[0]) > 0:
+            ax.legend(loc='best',frameon=False)
     plt.tight_layout()
     
     # Output

--- a/src/gne/gne_slurm.py
+++ b/src/gne/gne_slurm.py
@@ -91,7 +91,7 @@ def generate_job_name(param_file, simpath, snap, subvols,
         Path to the catalogues
     snap : int
         Snapshot number
-    subvols : list of integers
+    subvols : integer or list of integers
         List of subvolumes
     job_suffix : string or None
         User-defined suffix. If None, derived from cutcols/limits in param_file
@@ -106,6 +106,17 @@ def generate_job_name(param_file, simpath, snap, subvols,
     
     # Create subvols representation
     subvols_str = str(subvols)
+    if isinstance(subvols, list):
+        subvols_str = str(subvols[0])
+        if len(subvols) > 1:
+            subvols_sort = subvols.copy()
+            subvols_sort.sort()
+            item_0 = subvols_sort[0]
+            item_n = subvols_sort[-1]
+            if subvols_sort == list(range(item_0, item_n + 1)):
+                subvols_str = f'{item_0}-{item_n}'
+            else:
+                subvols_str = "_".join(map(str, subvols))        
     
     # Get suffix from cutcols if not provided
     if job_suffix is None:
@@ -194,8 +205,8 @@ def create_slurm_script(hpc, param_file, simpath, snap, subvols,
         Simulation snapshot number 
     subvols : list of integers
         List of subvolumes
-    outdir : string
-        Name of output directory, if different from output/
+    logdir : string
+        Name of log directory
     verbose : bool
         Verbose output flag
     job_suffix : string or None

--- a/tests/test_Lagn.py
+++ b/tests/test_Lagn.py
@@ -1,13 +1,13 @@
 #python -m unittest tests/test_Lagn.py 
 
-from unittest import TestCase
+import unittest
 import numpy as np
 from numpy.testing import assert_allclose
 
 import gne.gne_const as c
 import gne.gne_Lagn as agn
 
-class TestPredict(TestCase):
+class TestPredict(unittest.TestCase):
     def test_Ledd(self):
         mbh0 = 1e-38; val0 = 1.26
         self.assertAlmostEqual(agn.get_Ledd(mbh0),val0,2)

--- a/tests/test_Lagn.py
+++ b/tests/test_Lagn.py
@@ -1,6 +1,7 @@
 #python -m unittest tests/test_Lagn.py 
 
 import unittest
+from unittest.mock import patch
 import numpy as np
 from numpy.testing import assert_allclose
 
@@ -68,6 +69,36 @@ class TestPredict(unittest.TestCase):
         mdot.fill(mdot0); mbh.fill(mbh0); val.fill(val0)
         assert_allclose(agn.get_Lagn_H14(mdot,mbh),val,rtol=0.01)
         
+
+
+class TestGetLagn(unittest.TestCase):
+    @patch('gne.gne_Lagn.read_data')
+    def test_get_Lagn_input_Lagn(self, mock_read_data):
+        # Setup mock return value
+        # read_data returns a tuple of arrays.
+        # For Lagn_inputs='Lagn', it expects one array returned in vals[0]
+        lagn_val = np.array([1.0, 2.0, 3.0])
+        mock_read_data.return_value = (lagn_val,)
+
+        # Test case 1: units_L40h2=0 (default)
+        result = agn.get_Lagn(infile='dummy.hdf5', cut=None, Lagn_inputs='Lagn', units_L40h2=0)
+        assert_allclose(result, lagn_val)
+
+        # Test case 2: units_L40h2=1
+        h0 = 0.7
+        expected_result = lagn_val * 1e40 / (h0 * h0)
+        result = agn.get_Lagn(infile='dummy.hdf5', cut=None, Lagn_inputs='Lagn', units_L40h2=1, h0=h0)
+        assert_allclose(result, expected_result)
+
+        # Test case 3: units_L40h2=2
+        expected_result = lagn_val * 1e40
+        result = agn.get_Lagn(infile='dummy.hdf5', cut=None, Lagn_inputs='Lagn', units_L40h2=2)
+        assert_allclose(result, expected_result)
+
+        # Test case 4: units_L40h2=3 (ValueError)
+        with self.assertRaisesRegex(ValueError, 'units_L40h2 must be 0, 1 or 2'):
+            agn.get_Lagn(infile='dummy.hdf5', cut=None, Lagn_inputs='Lagn', units_L40h2=3)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_Lagn.py
+++ b/tests/test_Lagn.py
@@ -80,24 +80,24 @@ class TestGetLagn(unittest.TestCase):
         lagn_val = np.array([1.0, 2.0, 3.0])
         mock_read_data.return_value = (lagn_val,)
 
-        # Test case 1: units_L40h2=0 (default)
-        result = agn.get_Lagn(infile='dummy.hdf5', cut=None, Lagn_inputs='Lagn', units_L40h2=0)
+        # Test case 1: units_L=0 (default)
+        result = agn.get_Lagn(infile='dummy.hdf5', cut=None, Lagn_inputs='Lagn', units_L=0)
         assert_allclose(result, lagn_val)
 
-        # Test case 2: units_L40h2=1
+        # Test case 2: units_L=1
         h0 = 0.7
         expected_result = lagn_val * 1e40 / (h0 * h0)
-        result = agn.get_Lagn(infile='dummy.hdf5', cut=None, Lagn_inputs='Lagn', units_L40h2=1, h0=h0)
+        result = agn.get_Lagn(infile='dummy.hdf5', cut=None, Lagn_inputs='Lagn', units_L=1, h0=h0)
         assert_allclose(result, expected_result)
 
-        # Test case 3: units_L40h2=2
+        # Test case 3: units_L=2
         expected_result = lagn_val * 1e40
-        result = agn.get_Lagn(infile='dummy.hdf5', cut=None, Lagn_inputs='Lagn', units_L40h2=2)
+        result = agn.get_Lagn(infile='dummy.hdf5', cut=None, Lagn_inputs='Lagn', units_L=2)
         assert_allclose(result, expected_result)
 
-        # Test case 4: units_L40h2=3 (ValueError)
-        with self.assertRaisesRegex(ValueError, 'units_L40h2 must be 0, 1 or 2'):
-            agn.get_Lagn(infile='dummy.hdf5', cut=None, Lagn_inputs='Lagn', units_L40h2=3)
+        # Test case 4: units_L=3 (ValueError)
+        with self.assertRaisesRegex(ValueError, 'units_L must be 0, 1 or 2'):
+            agn.get_Lagn(infile='dummy.hdf5', cut=None, Lagn_inputs='Lagn', units_L=3)
 
 
 if __name__ == '__main__':

--- a/tests/test_att.py
+++ b/tests/test_att.py
@@ -1,13 +1,13 @@
 #python -m unittest tests/test_att.py 
 
-from unittest import TestCase
+import unittest
 import numpy as np
 from numpy.testing import assert_allclose
 
 import gne.gne_const as c
 import gne.gne_att as att
 
-class TestPredict(TestCase):
+class TestPredict(unittest.TestCase):
     def test_get_f_saito20(self):
         expect = 1
         self.assertAlmostEqual(att.get_f_saito20(2.9),expect,2)
@@ -52,4 +52,4 @@ class TestPredict(TestCase):
 
         
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main(verbosity=2)

--- a/tests/test_epsilon.py
+++ b/tests/test_epsilon.py
@@ -1,11 +1,11 @@
 #python -m unittest tests/test_epsilon.py 
 
-from unittest import TestCase
+import unittest
 import numpy as np
 import gne.gne_const as c
 import gne.gne_epsilon as e
 
-class TestPredict(TestCase):
+class TestPredict(unittest.TestCase):
     atol = 1e-7
     
     def test_surface_density_disc(self):

--- a/tests/test_flux.py
+++ b/tests/test_flux.py
@@ -1,6 +1,6 @@
 # python -m unittest tests/test_flux.py 
 
-from unittest import TestCase
+import unittest
 import numpy as np
 from numpy.testing import assert_allclose
 from unittest.mock import patch
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import gne.gne_cosmology as cosmo
 import gne.gne_flux as fx
 
-class TestPredict(TestCase):
+class TestPredict(unittest.TestCase):
     def test_L2flux(self):
         """Set up cosmology for tests."""
         cosmo.set_cosmology(omega0=0.3, omegab=0.045, lambda0=0.7, h0=0.7)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -19,7 +19,7 @@ hf5file = opath+nom+'.hdf5'
 class TestStringMethods(unittest.TestCase):
     def test_outroot(self):
         snap = 61
-        rootdir = os.path.dirname(os.path.abspath(sys.argv[0]))
+        rootdir = c.repo_dir
         expath = os.path.join(rootdir,'output','iz'+str(snap),'ivol')
         dirf, endf = io.get_outroot(snap,'example.txt')
         self.assertEqual(dirf,expath)
@@ -95,7 +95,7 @@ class TestStringMethods(unittest.TestCase):
         filenom = io.generate_header(hf5file,0,100,h0,0.4,0.3,0.6,1,1e8,
                                      outpath=expath,verbose=False)
         # Updated expectation: get_outnom strips 'test' from path
-        self.assertEqual(filenom,'output/iz61/ivol0/'+nom+'.hdf5')
+        self.assertEqual(filenom,'output/test/iz61/ivol0/'+nom+'.hdf5')
         
         names = ['a','b',None]
         values = [1,'b',3]

--- a/tests/test_model_UnH.py
+++ b/tests/test_model_UnH.py
@@ -3,14 +3,13 @@
 import shutil
 import unittest
 import os
-from unittest import TestCase
 import numpy as np
 import gne.gne_io as io
 import gne.gne_const as c
 import gne.gne_model_UnH as unh
 
 
-class TestPredict(TestCase):
+class TestPredict(unittest.TestCase):
     decimals = 8
     atol = 1e-7
 

--- a/tests/test_photio.py
+++ b/tests/test_photio.py
@@ -1,8 +1,8 @@
 #python -m unittest tests/test_photio.py 
 
+import unittest
 import shutil
 import os
-from unittest import TestCase
 import numpy as np
 from numpy.testing import assert_allclose
 
@@ -10,7 +10,7 @@ import gne.gne_const as c
 import gne.gne_io as io
 import gne.gne_photio as ph
 
-class TestPredict(TestCase):
+class TestPredict(unittest.TestCase):
     decimals = 8
     atol = 1e-7
 

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -1,7 +1,7 @@
 #python -m unittest tests/test_plots.py 
 
+import unittest
 import pytest
-from unittest import TestCase
 import numpy as np
 from numpy.testing import assert_allclose
 import os
@@ -16,7 +16,7 @@ required_file = ex_root+'0/'+ex_end
 @pytest.mark.skipif(not os.path.exists(required_file), 
                    reason=f"Test data file not found: {required_file}")
 
-class TestPredict(TestCase):
+class TestPredict(unittest.TestCase):
     def test_contour2Dsigma(self):
         levels,colors = plt.contour2Dsigma()
         assert_allclose(levels[1:],c.sigma_2Dprobs,rtol=0.01)

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -4,6 +4,8 @@ import unittest
 import os
 import tempfile
 import shutil
+import sys
+from unittest.mock import patch
 
 import gne.gne_const as c
 import gne.gne_slurm as su
@@ -18,13 +20,13 @@ class TestSlurmUtilsHdf5(unittest.TestCase):
         
         # Create a mock SLURM template file for testing
         cls.template_content = '''#!/bin/sh
-#SBATCH --job-name=JOB_NAME
-#SBATCH --output=output/JOB_NAME.out
-#SBATCH --error=output/JOB_NAME.err
-
-srun python -c '
-PARAM_CONTENT
-'
+#SBATCH --job-name=__GNE_JOB_NAME__
+#SBATCH --error=__GNE_LOG_DIR__/__GNE_JOB_NAME__.err
+#SBATCH --output=__GNE_LOG_DIR__/__GNE_JOB_NAME__.out
+#
+srun python << 'EOF_PYTHON_SCRIPT'
+__GNE_PARAM_CONTENT__
+EOF_PYTHON_SCRIPT
 '''
         # Create a mock parameter file for testing
         cls.param_content = '''import gne.gne_const as const
@@ -78,7 +80,7 @@ for ivol in range(subvols):
             try:
                 shutil.rmtree(cls.test_dir)
             except (OSError, PermissionError) as e:
-                print(f"Warning: Could not remove test directory {cls.test_dir}: {e}")
+                print("Warning: Could not remove test directory {}: {}".format(cls.test_dir, e))
         
         # Restore original template or remove test template
         if cls.taurus_backup is not None:
@@ -108,27 +110,39 @@ root = '/path/iz87/ivol'
     def test_generate_job_name(self):
         """Test job name generation with various configurations"""
         # Single subvolume with auto suffix
-        job_name = su.generate_job_name(self.param_file_path, 87, [0])
+        job_name = su.generate_job_name(self.param_file_path, simpath='TestSim', snap=87, subvols=[0])
         self.assertEqual(job_name, 'gne_TestSim_iz87_iv0_Lbol_AGN_min')
         
         # Two subvolumes with auto suffix
-        job_name = su.generate_job_name(self.param_file_path, 128, [0, 1])
-        self.assertEqual(job_name, 'gne_TestSim_iz128_iv0_1_Lbol_AGN_min')
+        job_name = su.generate_job_name(self.param_file_path, simpath='TestSim', snap=128, subvols=[0, 1])
+        self.assertEqual(job_name, 'gne_TestSim_iz128_iv0-1_Lbol_AGN_min')
 
         # Three subvolumes with auto suffix
-        job_name = su.generate_job_name(self.param_file_path, 104, [0, 1, 2])
+        job_name = su.generate_job_name(self.param_file_path, simpath='TestSim', snap=104, subvols=[0, 1, 2])
         self.assertEqual(job_name, 'gne_TestSim_iz104_iv0-2_Lbol_AGN_min')
+
+        # Four subvolumes with auto suffix
+        job_name = su.generate_job_name(self.param_file_path, simpath='TestSim', snap=104, subvols=[4, 5, 6, 7])
+        self.assertEqual(job_name, 'gne_TestSim_iz104_iv4-7_Lbol_AGN_min')
+
+        # Four subvolumes with auto suffix
+        job_name = su.generate_job_name(self.param_file_path, simpath='TestSim', snap=104, subvols=[5, 4, 6, 7])
+        self.assertEqual(job_name, 'gne_TestSim_iz104_iv4-7_Lbol_AGN_min')
+
+        # Four subvolumes with auto suffix
+        job_name = su.generate_job_name(self.param_file_path, simpath='TestSim', snap=104, subvols=[4, 5, 7])
+        self.assertEqual(job_name, 'gne_TestSim_iz104_iv4_5_7_Lbol_AGN_min')
         
         # With user-defined suffix
-        job_name = su.generate_job_name(self.param_file_path, 87, [0], job_suffix='custom')
+        job_name = su.generate_job_name(self.param_file_path, simpath='TestSim', snap=87, subvols=[0], job_suffix='custom')
         self.assertEqual(job_name, 'gne_TestSim_iz87_iv0_custom')
 
     def test_get_slurm_template_valid(self):
         """Test reading a valid template file"""
         template = su.get_slurm_template('taurus')
         self.assertIsNotNone(template)
-        self.assertIn('JOB_NAME', template)
-        self.assertIn('PARAM_CONTENT', template)
+        self.assertIn('__GNE_JOB_NAME__', template)
+        self.assertIn('__GNE_PARAM_CONTENT__', template)
 
     def test_get_slurm_template_invalid(self):
         """Test that invalid HPC name causes sys.exit()"""
@@ -137,7 +151,7 @@ root = '/path/iz87/ivol'
 
     def test_modify_param_file(self):
         """Test modification of parameter file content"""
-        modified = su.modify_param_file(self.param_file_path, 128, [0, 1, 2, 3])
+        modified = su.modify_param_file(self.param_file_path, simpath='TestSim', snap=128, subvols=4)
 
         # Check subvols was modified
         self.assertIn('subvols = 4', modified)
@@ -147,15 +161,28 @@ root = '/path/iz87/ivol'
         self.assertIn('iz128', modified)
         self.assertNotIn('iz87', modified)
 
+    def test_modify_param_file_list(self):
+        """Test modification of parameter file content with list of subvolumes"""
+        modified = su.modify_param_file(self.param_file_path, simpath='TestSim', snap=128, subvols=[42, 63])
+
+        # Check subvols was modified
+        self.assertIn('subvols = [42, 63]', modified)
+        self.assertNotIn('subvols = 2', modified)
+        
+        # Check root path was modified with new snapshot
+        self.assertIn('iz128', modified)
+        self.assertNotIn('iz87', modified)
+
+
     def test_create_slurm_script(self):
         """Test creating a SLURM script with parameter file embedding"""
         script_path, job_name = su.create_slurm_script(
-            'taurus', self.param_file_path, 87, [0, 1],
-            outdir=self.test_dir, verbose=True
+            'taurus', self.param_file_path, simpath='TestSim', snap=87, subvols=[0, 1],
+            logdir=self.test_dir, verbose=True
         )
         
         # Check returned values
-        self.assertEqual(job_name, 'gne_TestSim_iz87_iv0_1_Lbol_AGN_min')
+        self.assertEqual(job_name, 'gne_TestSim_iz87_iv0-1_Lbol_AGN_min')
         self.assertTrue(script_path.endswith(f'submit_{job_name}.sh'))
         
         # Check file was created
@@ -166,19 +193,19 @@ root = '/path/iz87/ivol'
             content = f.read()
         
         # Job name should be replaced
-        self.assertIn('gne_TestSim_iz87_iv0_1_Lbol_AGN_min', content)
-        self.assertNotIn('JOB_NAME', content)
+        self.assertIn('gne_TestSim_iz87_iv0-1_Lbol_AGN_min', content)
+        self.assertNotIn('__GNE_JOB_NAME__', content)
         
         # Parameter content should be embedded
         self.assertIn('get_emission_lines = True', content)
-        self.assertIn('subvols = 2', content)  # Modified for 2 subvols
-        self.assertNotIn('PARAM_CONTENT', content)
+        self.assertIn('subvols = [0, 1]', content)
+        self.assertNotIn('__GNE_PARAM_CONTENT__', content)
 
     def test_create_slurm_script_with_custom_suffix(self):
         """Test creating a SLURM script with custom job suffix"""
         script_path, job_name = su.create_slurm_script(
-            'taurus', self.param_file_path, 90, [0],
-            outdir=self.test_dir, verbose=True,
+            'taurus', self.param_file_path, simpath='TestSim', snap=90, subvols=[0],
+            logdir=self.test_dir, verbose=True,
             job_suffix='lbol45'
         )
         
@@ -188,16 +215,16 @@ root = '/path/iz87/ivol'
         """Test creating a SLURM script with non-existent parameter file"""
         with self.assertRaises(SystemExit):
             su.create_slurm_script(
-                'taurus', 'nonexistent_file.py', 87, [0],
-                outdir=self.test_dir, verbose=True
+                'taurus', 'nonexistent_file.py', simpath='TestSim', snap=87, subvols=[0],
+                logdir=self.test_dir, verbose=True
             )
 
     def test_create_slurm_script_invalid_hpc(self):
         """Test creating a SLURM script with invalid HPC -> sys.exit()"""
         with self.assertRaises(SystemExit):
             su.create_slurm_script(
-                'invalid_hpc', self.param_file_path, 87, [0],
-                outdir=self.test_dir, verbose=True
+                'invalid_hpc', self.param_file_path, simpath='TestSim', snap=87, subvols=[0],
+                logdir=self.test_dir, verbose=True
             )
 
     def test_submit_slurm_job_no_sbatch(self):


### PR DESCRIPTION
## Description
This PR introduces several improvements to the codebase:

### Key Changes

**Subvolume Handling Enhancements**
- Refactored `gne_plots.py` and `gne_slurm.py` to support `subvols` as both integers and lists of integers
- Improved subvolume representation in job names with smart formatting (e.g., `iv0-7` for consecutive ranges, `iv4_5_7` for non-consecutive)
- Fixed data aggregation initialization in plotting functions to prevent issues with empty datasets

**Unit Testing Improvements**
- Standardized test imports by replacing `from unittest import TestCase` with `import unittest`
- Added comprehensive unit tests for SLURM utilities (`test_slurm.py`)
- Added unit tests for `get_Lagn` function covering different `units_L40h2` parameter values
- Replaced file-based template management with mocking in tests to avoid modifying original files
- Resolve ModuleNotFoundError for 'gne' in CI pipeline. Update the PYTHONPATH in the GitHub Actions workflow to include the src directory, ensuring the 'gne' module is correctly discovered during test execution.

**Luminosity Units Enhancement**
- Changed `units_L40h2` parameter from boolean to integer (0, 1, 2) for more flexible luminosity unit specification:
  - 0: erg/s (default)
  - 1: 1e40 h^-2 erg/s
  - 2: 1e40 erg/s

**Other Improvements**
- Added `.venv/` to `.gitignore`
- Excluded 'epi' node in Taurus SLURM template
- Fixed empty legend issues in plotting functions