### PR TITLE
fix: Prevent output file from overwriting input file and optional cutcols support.

### DIFF
--- a/src/gne/gne_io.py
+++ b/src/gne/gne_io.py
@@ -442,10 +442,10 @@ def get_selection(infile, outfile, inputformat='hdf5',
         sys.exit()
     elif inputformat=='hdf5':
         with h5py.File(infile, 'r') as hf:
-            key = [k for k in hf.keys() if k != 'header'][0]
-            ind = np.arange(len(hf[key]))
-
-            if not (len(cutcols)==0 or cutcols==[None]):
+            if len(cutcols)==0 or cutcols==[None]:
+                key = [k for k in hf.keys() if k != 'header'][0]
+                ind = np.arange(len(hf[key]))
+            else:
                 ind = np.arange(len(hf[cutcols[0]][:]))
 
             for i in range(len(cutcols)):
@@ -464,8 +464,9 @@ def get_selection(infile, outfile, inputformat='hdf5',
     elif inputformat=='txt':
         ih = get_nheader(infile)
 
-        ind = np.arange(len(np.loadtxt(infile, usecols=0, skiprows=ih)))
-        if not (len(cutcols) == 0 or cutcols == [None]):
+        if len(cutcols) == 0 or cutcols == [None]:
+            ind = np.arange(len(np.loadtxt(infile, usecols=0, skiprows=ih)))
+        else:
             ind = np.arange(len(np.loadtxt(infile,usecols=cutcols[0],skiprows=ih)))
 
         for i in range(len(cutcols)):

--- a/src/gne/gne_io.py
+++ b/src/gne/gne_io.py
@@ -171,6 +171,10 @@ def get_outnom(filenom,dirf=None,nomf=None,verbose=False):
     create_dir(root)
 
     outfile = os.path.join(root, nom+'.hdf5')
+    if outfile == filenom:
+        outfile = os.path.join(root, nom+'_output.hdf5')
+        print(f'WARNING: outfile is the same as filenom {filenom}. Renaming outfile to {outfile}')
+
     if verbose:
         print(f'* Output: {outfile}')
     return outfile

--- a/src/gne/gne_io.py
+++ b/src/gne/gne_io.py
@@ -424,6 +424,9 @@ def get_selection(infile, outfile, inputformat='hdf5',
     '''
 
     selection = None
+
+    if cutcols is None:
+        cutcols = [None]
     
     check_file(infile, verbose=verbose)
 
@@ -439,7 +442,12 @@ def get_selection(infile, outfile, inputformat='hdf5',
         sys.exit()
     elif inputformat=='hdf5':
         with h5py.File(infile, 'r') as hf:
-            ind = np.arange(len(hf[cutcols[0]][:]))
+            key = [k for k in hf.keys() if k != 'header'][0]
+            ind = np.arange(len(hf[key]))
+
+            if not (len(cutcols)==0 or cutcols==[None]):
+                ind = np.arange(len(hf[cutcols[0]][:]))
+
             for i in range(len(cutcols)):
                 if cutcols[i]:
                     param = hf[cutcols[i]][:]
@@ -455,7 +463,10 @@ def get_selection(infile, outfile, inputformat='hdf5',
             selection = ind[:limit]
     elif inputformat=='txt':
         ih = get_nheader(infile)
-        ind = np.arange(len(np.loadtxt(infile,usecols=cutcols[0],skiprows=ih)))
+
+        ind = np.arange(len(np.loadtxt(infile, usecols=0, skiprows=ih)))
+        if not (len(cutcols) == 0 or cutcols == [None]):
+            ind = np.arange(len(np.loadtxt(infile,usecols=cutcols[0],skiprows=ih)))
 
         for i in range(len(cutcols)):
             if cutcols[i]:


### PR DESCRIPTION
## Description

This PR introduces two improvements to the `gne_io.py` module:

## Changes

### 1. Prevent input file overwriting (7bcba98)
- Added automatic detection when output file path matches input file path
- Automatically renames output file by appending `_output` suffix to prevent data loss
- Includes warning message to inform users of the rename

### 2. Make `cutcols` optional in `get_selection` (c7498e7)
- Enhanced `get_selection` function to handle cases where `cutcols` is `None`, `[]`, or `[None]`
- Automatically generates default index containing all elements when no columns are specified
- Implemented for both HDF5 and TXT input formats
- Uses first available dataset key (excluding 'header') for HDF5 files
- Falls back to column 0 for TXT files
